### PR TITLE
[Doppins] Upgrade dependency Django to ==1.9.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ amqp==2.0.3
 anyjson==0.3.3
 billiard==3.3.0.23
 celery==3.1.23
-Django==1.9.7
+Django==1.9.8
 feedparser==5.2.1
 kombu==3.0.35
 mock==2.0.0


### PR DESCRIPTION
Hi!

A new version was just released of `Django`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded Django from `==1.9.7` to `==1.9.8`

